### PR TITLE
Fix connections to LDAP server are never closed

### DIFF
--- a/app.go
+++ b/app.go
@@ -33,6 +33,7 @@ func ldapCheck(user user) bool {
 		l, err = ldap.Dial("tcp", os.Getenv("ICECAST_AUTH_LDAP_SRV")+":389")
 		check(err)
 	}
+	defer l.Close()
 
 	err := l.Bind("uid="+user.name+","+os.Getenv("ICECAST_AUTH_LDAP_DN"), user.password)
 	if err != nil {


### PR DESCRIPTION
While running in production for some time, I noticed that the connections to the ldap server were never closed. Maybe later the connection should also be reused for better efficiency.
